### PR TITLE
Add hurricane CSV download script and map viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # WeatherLab
-Test
+
+This project provides simple scripts for downloading hurricane track CSV files from DeepMind's Weather Lab and visualizing them on a map.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   pip install flask requests beautifulsoup4 selenium webdriver-manager
+   ```
+   A Chrome browser is required for the downloader script.
+
+2. Download the latest CSV:
+   ```bash
+   python weather-map/scripts/download_latest.py
+   ```
+   The file is saved in `weather-map/data/` with a date-based filename.
+
+3. Start the map server:
+   ```bash
+   python weather-map/app.py
+   ```
+   Open `http://localhost:5000/` in your browser to view the Leaflet map.
+
+CSV files placed in `weather-map/data/` are automatically listed and displayed on the map.

--- a/weather-map/app.py
+++ b/weather-map/app.py
@@ -1,0 +1,23 @@
+import os
+from flask import Flask, send_from_directory, jsonify
+
+app = Flask(__name__)
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+
+@app.route('/')
+def index():
+    return send_from_directory('static', 'leaflet.html')
+
+@app.route('/data/<path:filename>')
+def data(filename):
+    return send_from_directory(DATA_DIR, filename)
+
+@app.route('/list')
+def list_files():
+    files = [f for f in os.listdir(DATA_DIR) if f.endswith('.csv')]
+    return jsonify(sorted(files))
+
+if __name__ == '__main__':
+    os.makedirs(DATA_DIR, exist_ok=True)
+    app.run(debug=True)

--- a/weather-map/scripts/download_latest.py
+++ b/weather-map/scripts/download_latest.py
@@ -1,0 +1,51 @@
+import os
+import time
+from datetime import datetime
+
+import requests
+from bs4 import BeautifulSoup
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
+from webdriver_manager.chrome import ChromeDriverManager
+
+
+def fetch_latest_csv():
+    """Download the latest hurricane track CSV from DeepMind Weather Lab."""
+    # Headless Chrome so the script can run without a GUI
+    options = Options()
+    options.add_argument("--headless")
+    driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
+
+    try:
+        driver.get("https://deepmind.google.com/science/weatherlab")
+        # Allow dynamic content to load
+        time.sleep(5)
+
+        # Parse the page for a link ending with .csv
+        soup = BeautifulSoup(driver.page_source, "html.parser")
+        csv_url = None
+        for link in soup.find_all("a", href=True):
+            href = link["href"]
+            if href.endswith(".csv"):
+                csv_url = href
+                break
+    finally:
+        driver.quit()
+
+    if not csv_url:
+        raise RuntimeError("CSV download link not found.")
+
+    # Save the file in the data directory with a timestamp-based name
+    today = datetime.utcnow().strftime("%Y-%m-%d")
+    os.makedirs("weather-map/data", exist_ok=True)
+    filename = f"FNV3_{today}.csv"
+    response = requests.get(csv_url)
+    response.raise_for_status()
+    with open(os.path.join("weather-map/data", filename), "wb") as fh:
+        fh.write(response.content)
+    print(f"Downloaded {filename}")
+
+
+if __name__ == "__main__":
+    fetch_latest_csv()

--- a/weather-map/static/leaflet.html
+++ b/weather-map/static/leaflet.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Hurricane Tracks</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-sA+zN/l6OhTfje39qTpsKq0p9kk3V6cSMkS4HQ+cmiY="
+    crossorigin=""
+  />
+  <style>
+    #map { height: 100vh; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script
+    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-pQN081Cu8B41u1D68SPrmlg7fSQu0QvhT3LrAPAc+5I="
+    crossorigin=""
+  ></script>
+  <script>
+    const map = L.map('map').setView([20, -60], 4);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 10,
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+
+    async function loadCsv(file) {
+      const response = await fetch('/data/' + file);
+      const text = await response.text();
+      const rows = text.trim().split('\n').slice(1);
+      const points = rows.map(row => {
+        const [time, lat, lon, wind, pressure] = row.split(',');
+        return { time, lat: +lat, lon: +lon, wind, pressure };
+      });
+      const latlngs = points.map(p => [p.lat, p.lon]);
+      const polyline = L.polyline(latlngs, { color: 'red' }).addTo(map);
+      polyline.on('mouseover', () => {
+        const last = points[points.length - 1];
+        polyline.bindPopup(
+          `Time: ${last.time}<br>Wind: ${last.wind}<br>Pressure: ${last.pressure}`
+        ).openPopup();
+      });
+    }
+
+    fetch('/list')
+      .then(r => r.json())
+      .then(files => files.forEach(loadCsv));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add instructions to README
- add script to fetch hurricane track CSV from DeepMind Weather Lab
- show hurricanes on a Leaflet map
- serve data and map with a small Flask app

## Testing
- `pip install requests beautifulsoup4 selenium webdriver-manager`
- `python weather-map/scripts/download_latest.py` *(fails: Could not reach host)*

------
https://chatgpt.com/codex/tasks/task_e_686b32f5056c83288e421f1f448f3ce3